### PR TITLE
Remove 'crypto' module dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.8.17",
       "license": "MPLv2",
       "dependencies": {
-        "axios": "^0.21.2",
-        "crypto": "^1.0.1"
+        "axios": "^0.21.2"
       },
       "devDependencies": {
         "@types/node": "^15.0.2",
@@ -479,12 +478,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -1909,11 +1902,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "debug": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "axios": "^0.21.2",
-    "crypto": "^1.0.1"
+    "axios": "^0.21.2"
   }
 }


### PR DESCRIPTION
crypto module is deprecated as it's part of node:
- https://www.npmjs.com/package/crypto
- https://nodejs.org/api/crypto.html