### PR TITLE
Lowercase to businessCreditCard

### DIFF
--- a/types/cards.ts
+++ b/types/cards.ts
@@ -165,7 +165,7 @@ export type BusinessDebitCard = BaseCard & {
 }
 
 export type BusinessCreditCard = BaseCard & {
-    type: "BusinessCreditCard"
+    type: "businessCreditCard"
 
     /**
      * JSON object representing the card data.


### PR DESCRIPTION
This needs to be lowercase for it to work as expected

https://github.com/highbeamco/unit-node-sdk/blob/main/types/cards.ts#L6